### PR TITLE
Add Paz.ai to Platforms & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Solenya](https://www.solenya.ai/)
 - [Saleor](https://saleor.io/agentic-commerce)
 - [OrcaQubits](https://orcaqubits-ai.com/)
+- [Paz.ai](https://paz.ai/)
 - [Zinc](https://www.zinc.com/)
 
 ## 🧩 Protocol Deep Dives


### PR DESCRIPTION
Adds [Paz.ai](https://paz.ai/) to the Platforms & Tools section.

Paz.ai is an AI-native commerce infrastructure platform that enables merchants to sell products directly within AI assistants — with in-chat checkout, catalog optimization for AI discovery, and real-time analytics across AI platforms.