### PR TITLE
Add BCP Protocol (Business Commerce Protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This repository exists to document, track, and make sense of that shift.
 - [github.com/daydreamsai/lucid-agents](https://github.com/daydreamsai/lucid-agents)
 - [github.com/0xRustElite1111/x402-payments-protocol](https://github.com/0xRustElite1111/x402-payments-protocol)
 - [github.com/Logarithm-Labs/yield-analysis-sdk](https://github.com/Logarithm-Labs/yield-analysis-sdk)
+- [github.com/lucidedev/bcp-protocol](https://github.com/lucidedev/bcp-protocol) — Business Commerce Protocol: agent-to-agent B2B negotiation, escrow, and settlement over x402. TypeScript SDK on npm.
 
 ## 🤝 Contributing
 Have a link suggestion? Open a PR or issue.


### PR DESCRIPTION
Adds [BCP](https://github.com/lucidedev/bcp-protocol) to the Notable Github Projects section.

BCP is an open-source protocol for agent-to-agent B2B commerce — the negotiation and escrow layer that sits alongside x402 (payments) and A2A (communication). While ACP and UCP handle agent-to-merchant checkout, BCP handles agent-to-agent deals where both sides need to negotiate terms, lock funds in escrow, and settle on delivery.

- 6 typed messages: Intent, Quote, Counter, Commit, Fulfil, Dispute
- Ed25519 signed messages
- On-chain USDC escrow on Base
- TypeScript SDK: `npm install @bcp-protocol/sdk`
- Apache 2.0 licensed