### PR TITLE
Add Voidly Pay — open ledger with x402 + A2A v0.3.0 bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Saleor](https://saleor.io/agentic-commerce)
 - [OrcaQubits](https://orcaqubits-ai.com/)
 - [Zinc](https://www.zinc.com/)
+- [Voidly Pay](https://voidly.ai/pay) — Open off-chain credit ledger for agent-to-agent payments with bridges for x402 and A2A v0.3.0. Ed25519-signed envelopes, escrow, hire workflow, 9 framework adapters (LangChain, CrewAI, AutoGen, LlamaIndex, Haystack, Vercel AI, OpenAI-compat, x402, A2A).
 
 ## 🧩 Protocol Deep Dives
 
@@ -188,6 +189,8 @@ This repository exists to document, track, and make sense of that shift.
 - [github.com/daydreamsai/lucid-agents](https://github.com/daydreamsai/lucid-agents)
 - [github.com/0xRustElite1111/x402-payments-protocol](https://github.com/0xRustElite1111/x402-payments-protocol)
 - [github.com/Logarithm-Labs/yield-analysis-sdk](https://github.com/Logarithm-Labs/yield-analysis-sdk)
+- [github.com/voidly-ai/voidly-pay](https://github.com/voidly-ai/voidly-pay) — Off-chain credit ledger + SDKs with x402 and A2A v0.3.0 bridges
+- [github.com/voidly-ai/voidly-agent-relay](https://github.com/voidly-ai/voidly-agent-relay) — E2E encrypted A2A messaging (Double Ratchet + ML-KEM-768), pairs with Voidly Pay for the full A2A payments stack
 
 ## 🤝 Contributing
 Have a link suggestion? Open a PR or issue.


### PR DESCRIPTION
## Summary

Adds **Voidly Pay** — an open off-chain credit ledger for autonomous agent-to-agent payments — to *Platforms & Tools*, plus both Voidly Pay and Voidly Agent Relay to *Notable Github Projects*.

## Protocol Coverage

- **x402** — shipped bridge (x402 header protocol on HTTP 402)
- **A2A v0.3.0** — shipped bridge (Google Agent2Agent Protocol)
- **AP2** — on roadmap

## What Voidly Pay Is

- Ed25519-signed transfer envelopes (9-check settlement invariant)
- Escrow + hire workflow for delegated agent work
- Off-chain Stage 1 (no real-world value); Stage 2 swaps backing to USDC on Base without protocol changes
- Open source: https://github.com/voidly-ai/voidly-pay
- Landing: https://voidly.ai/pay

## Framework Adapters (9)

LangChain, CrewAI, AutoGen, LlamaIndex, Haystack, Vercel AI SDK, OpenAI-compat, x402, A2A.

## Companion: Voidly Agent Relay

Added under *Notable Github Projects* — E2E encrypted agent-to-agent messaging (Double Ratchet + X3DH + ML-KEM-768 post-quantum). Pairs with Voidly Pay for the full agentic A2A stack (messaging + payments).

## Checklist

- [x] Topically on-scope for this list (A2A / AP2 / x402 / ACP / UCP)
- [x] Actively maintained
- [x] Open source with public docs + code
- [x] No duplicate entry
- [x] Alphabetic/positional fit preserved (appended to end of each section, matching existing convention)

Maintainer: @EmperorMew