### PR TITLE
Add A2CN Protocol to negotiation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository exists to document, track, and make sense of that shift.
 - [A2UI Protocol](https://a2ui.org/)
 - [x402 Protocol (Coinbase Crypto Payment Protocol)](https://www.x402.org/)
 - [MDN - HTTP 402 Payment Required (Original RFC)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402)
+- [A2CN Protocol](https://a2cn.io)
 
 ## 🗂️ Official Github Projects
 - [OpenAI Agentic Commerce Protocol (ACP) Github](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol)


### PR DESCRIPTION
The protocols section covers discovery (A2A), commerce execution (UCP), and 
payment authorization (AP2/ACP) — but the negotiation layer between communication 
and settlement isn't represented yet.

A2CN is an open protocol for agent-to-agent commercial negotiation. It sits 
between A2A and AP2/ACP in the stack:

A2A (discovery) → A2CN (negotiation) → AP2 / ACP (payment)

Working reference implementation with Fairmarkit and Keelvar adapters, 202 tests 
passing, Apache 2.0. A2A extension proposal in progress, coordinating with 
Concordia Protocol (Erik Newton may submit that separately).

a2cn.io