### PR TITLE
Add Concordia Protocol to protocols section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository exists to document, track, and make sense of that shift.
 - [A2UI Protocol](https://a2ui.org/)
 - [x402 Protocol (Coinbase Crypto Payment Protocol)](https://www.x402.org/)
 - [MDN - HTTP 402 Payment Required (Original RFC)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402)
+- [Concordia Protocol](https://github.com/eriknewton/concordia-protocol)
 
 ## 🗂️ Official Github Projects
 - [OpenAI Agentic Commerce Protocol (ACP) Github](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol)


### PR DESCRIPTION
Adds Concordia Protocol to the Official Protocols & Core Systems section, as a companion submission to the open A2CN PR (#11).

## Concordia in one paragraph

Concordia Protocol is an open negotiation standard for AI agents. Structured negotiation with binding commitments, session receipts that bind external counterparties, and graceful degradation. Agents that have nothing in common except this protocol can still negotiate, commit, and produce a portable record of what was agreed. The Python SDK ships on PyPI as `concordia-protocol` (latest: 0.4.0).

## Why this fits the list

Agentic commerce needs a way for agents to make commitments that survive the negotiation. Payment rails (x402) bind value movement. Identity layers bind who is acting. Mandate frameworks (AP2) bind authorized scope. Concordia binds the negotiation outcome itself: sequence of state changes, conditional commitments each side makes, the receipt parties walk away with. Composes with everything else in this list rather than competing with any of it.

## Composition with A2CN PR #11

This is a coordinated pair with @cmagorr1's A2CN PR (#11). A2CN handles the authorization continuum (sits between A2A discovery and AP2/ACP payment per Christian's PR body). Concordia handles the negotiation primitive that produces commitments + receipts. The two are co-maintained under the `concordia-a2cn` GitHub org and ship as composition partners. Either PR can merge first; both are independently useful.

## Maintainer notes

- Line format matches the existing Official Protocols & Core Systems section: bare `- [Name](URL)`.
- Happy to expand to a description-bearing format if the maintainer prefers, or to relocate to a different section.
- Author: Erik Newton (@eriknewton).
