### PR TITLE
Add agentprobe — seller readiness scorer for agentic commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This repository exists to document, track, and make sense of that shift.
 - [A2A v0.3 Upgrade](https://cloud.google.com/blog/products/ai-machine-learning/agent2agent-protocol-is-getting-an-upgrade)
 
 ## 🧪 Developer Tools & Validation
+- [agentprobe](https://agentprobe.fly.dev) — Probe any seller URL and get a 0-95 readiness score across 10 checks: llms.txt, OpenAPI, ai-plugin.json, MCP endpoint, commerce.json, catalog/quote/checkout APIs, payment rail declarations, and refund/contact metadata. CI action + MCP server (`probe_site(url)`). Open source: [unitedideas/agentprobe](https://github.com/unitedideas/agentprobe)
 - [UCP Checker](https://ucpchecker.com/)
 - [UCP Lighthouse](https://ucp.rest/)
 - [Merchant Directory](https://merchants.awesomeucp.com/)


### PR DESCRIPTION
**What**: [agentprobe](https://github.com/unitedideas/agentprobe) — open-source tool that probes any seller URL and scores it 0-95 on agentic commerce readiness.

**Why it belongs in Developer Tools & Validation**: Before an agent tries to transact with a seller, it needs to know whether the seller surface is actually machine-readable enough to proceed. agentprobe fills that gap with 10 concrete checks:

- llms.txt, OpenAPI spec, ai-plugin.json, MCP endpoint
- commerce.json, catalog/quote/checkout APIs
- Payment rail declarations (x402, SPT, MPP, Stripe)
- Refund/contact metadata

Returns a grade: `NOT_READY` / `PARTIAL` / `AGENT_READY` / `CERTIFIED`

**Integration surfaces**:
- Live scorer: https://agentprobe.fly.dev
- MCP tool: `probe_site(url)` → full probe report JSON
- CI GitHub Action: fail builds if agentic readiness drops
- Open-source Go: https://github.com/unitedideas/agentprobe

Fits alongside UCP Checker and UCP Lighthouse as pre-transaction validation tooling.