### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Saleor](https://saleor.io/agentic-commerce)
 - [OrcaQubits](https://orcaqubits-ai.com/)
 - [Zinc](https://www.zinc.com/)
+- [NotFair](https://notfair.co) - Google Ads MCP server. Connect Claude and AI agents to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API. Source: github.com/nowork-studio/toprank. Free tier available.
 
 ## 🧩 Protocol Deep Dives
 


### PR DESCRIPTION
Adding NotFair under Platforms & Tools. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Happy to adjust the format if you'd prefer.