### PR TITLE
feat: add The Stall — x402 financial intelligence platform (210 pay-per-call caps, v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This repository exists to document, track, and make sense of that shift.
 - [OrcaQubits](https://orcaqubits-ai.com/)
 - [Zinc](https://www.zinc.com/)
 
+- [The Stall](https://the-stall.intuitek.ai) — 183 pay-per-call financial data tools via x402/USDC on Base (no API key required)
+
 ## 🧩 Protocol Deep Dives
 
 ### UCP (Universal Commerce Protocol)


### PR DESCRIPTION
## What is The Stall?

The Stall is a production x402 MCP server providing 210 pay-per-call financial data capabilities — market data, DeFi analytics, crypto intelligence, and prediction markets — settling via USDC micropayments on Base.

**Why it fits here:** The Stall is a live production implementation of the x402 protocol (listed in your Official Protocols section) for agentic financial commerce. AI agents query it, pay per call, no API key or subscription needed.

- **Live:** https://the-stall.intuitek.ai
- **GitHub:** https://github.com/thebrierfox/the-stall
- **Network:** Base (USDC micropayments)
- **Protocol:** x402 (HTTP 402 Payment Required)
- **Capabilities:** 210 tools — stock data, DeFi yields, options chains, prediction markets, crypto analytics, X/Twitter intel, Solana meme radar

git: d25c40a | version: v4.64.0 | caps: 210