### PR TITLE
Add GPT55 Model Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Stateset](https://www.stateset.com/)
 - [Simple Checkout](https://simplecheckout.ai/)
 - [MCP Pay](https://mcpay.tech/)
+- [GPT-5.5 x402 API Gateway](https://gpt55.558686.xyz/) - OpenAI-compatible GPT-5.5 chat and text tools with x402 Base USDC payments, $0.0001 compact requests, long/max-output tiers, OpenAPI metadata, AgentCard, agents402, and MCP discovery for autonomous buyers.
 - [Skyfire](https://skyfire.xyz/)
 - [PayOS](https://payos.ai/)
 - [Payman](https://paymanai.com/)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Stateset](https://www.stateset.com/)
 - [Simple Checkout](https://simplecheckout.ai/)
 - [MCP Pay](https://mcpay.tech/)
-- [GPT-5.5 x402 API Gateway](https://gpt55.558686.xyz/) - OpenAI-compatible GPT-5.5 chat and text tools with x402 Base USDC payments, $0.0001 compact requests, long/max-output tiers, OpenAPI metadata, AgentCard, agents402, and MCP discovery for autonomous buyers.
+- [GPT55 x402 Agent Tools](https://gpt55.558686.xyz/) - Remote x402 MCP/API gateway for OpenAI-compatible chat request shape plus deterministic URL, HTTP, JSON, text, and x402 seller utilities. Includes Base USDC settlement, OpenAPI metadata, AgentCard, agents402, MCP discovery, live pricing, and an editorial-safe directory listing at https://gpt55.558686.xyz/directory-listing.json.
 - [Skyfire](https://skyfire.xyz/)
 - [PayOS](https://payos.ai/)
 - [Payman](https://paymanai.com/)


### PR DESCRIPTION
Updates the listing to GPT55 Model Gateway, a remote x402 MCP/API gateway with an OpenAI-compatible chat request shape plus deterministic utility, wallet safety, x402 seller, buyer payment-control, and directory-readiness tools.

Canonical buyer/service hub: https://gpt55.558686.xyz/x402/service
Machine-readable hub JSON: https://gpt55.558686.xyz/x402/service.json
Public service root: https://gpt55.558686.xyz/
x402 discovery: https://gpt55.558686.xyz/.well-known/x402
Directory-safe listing: https://gpt55.558686.xyz/directory-listing.json

Current service: 32 MCP tools. The default model is GPT-5.6 Luna Standard, with GPT-5.6 Soul and Terra routes also available. The primary commercial offer is Key Pack 100: $11.1112 buys $100 of API quota. Paid execution remains on direct x402 HTTP endpoints.

Current five-project public-channel maintenance ledger: https://github.com/go165/gpt55-x402-gateway/blob/main/docs/channel-submission-pack/public-channel-maintenance-ledger.md