### PR TITLE
Add BuyWhere MCP server to Notable Github Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,5 +189,7 @@ This repository exists to document, track, and make sense of that shift.
 - [github.com/0xRustElite1111/x402-payments-protocol](https://github.com/0xRustElite1111/x402-payments-protocol)
 - [github.com/Logarithm-Labs/yield-analysis-sdk](https://github.com/Logarithm-Labs/yield-analysis-sdk)
 
+- [github.com/BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) — Open-source MCP server for AI agent commerce. Search 11M+ products across Singapore, SEA, and US markets via 8 MCP tools (search, compare, deals, categories). Free API keys. Live on the official MCP Registry as `io.github.BuyWhere/buywhere-mcp`.
+
 ## 🤝 Contributing
 Have a link suggestion? Open a PR or issue.


### PR DESCRIPTION
Adding [BuyWhere MCP server](https://github.com/BuyWhere/buywhere-mcp) to the Notable Github Projects section.

**What it is**: Open-source MCP server for AI agent commerce. Search 11M+ products across Singapore, SEA, and US markets via 8 MCP tools (search, compare, deals, categories, best-price, similar, ingest).

**Why it belongs here**: Live on the official MCP Registry as `io.github.BuyWhere/buywhere-mcp` (v1.0.5), serving real agent traffic. Free API key issuance (179+ keys registered). Working end-to-end example of agentic commerce with real product discovery, comparison, and affiliate-ready output — complements the protocol implementations already in this list (UCP, ACP, AP2) with a concrete deployable server.

**Maintenance**: Active. Last release 2026-06-14. Server.js publicly published via `mcp-publisher` to the official registry. 50M+ product catalog under continuous scrape and refresh.