### PR TITLE
Add Packrift UCP packaging resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This repository exists to document, track, and make sense of that shift.
 - [UCP Checker](https://ucpchecker.com/)
 - [UCP Lighthouse](https://ucp.rest/)
 - [Merchant Directory](https://merchants.awesomeucp.com/)
+- [Packrift UCP Shipping-Supplies Starter Kit](https://mcp.packrift.com/ai/packrift-ucp-shipping-supplies-starter-kit.html) - Live Shopify UCP packaging merchant and MCP endpoint for builders seeding boxes, mailers, bags, tape, labels, and stretch wrap.
 - [Agent Development Kit (ADK)](https://google.github.io/adk-docs/)
 - [ADK Python](https://github.com/google/adk-python)
 - [ADK Samples](https://github.com/google/adk-samples)


### PR DESCRIPTION
## Summary

Adds Packrift's UCP shipping-supplies starter kit to the Developer Tools & Validation section.

## Why this fits

- Packrift is a live Shopify packaging merchant with native UCP support.
- The public starter kit is useful for builders seeding UCP/agentic storefronts with packaging SKUs.
- The linked MCP endpoint covers boxes, mailers, bags, tape, labels, stretch wrap, and purchase handoff.

## Checks

- README-only change.
- Link is public and reachable: https://mcp.packrift.com/ai/packrift-ucp-shipping-supplies-starter-kit.html
- No private credentials, no test purchase, no pricing or catalog mutation.
