### PR TITLE
Add Vaaya to Platforms & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Google Universal Commerce Protocol (UCP) Github](https://github.com/Universal-Commerce-Protocol/ucp)
 
 ## 🧰 Platforms & Tools
+- [Vaaya](https://vaaya.ai/)
 - [Wild Card - YC W25](https://wild-card.ai/)
 - [TryChannel3 - YC S25](https://trychannel3.com/)
 - [PayWithLocus - YC F25](https://paywithlocus.com/)


### PR DESCRIPTION
Adds Vaaya to Platforms & Tools. Vaaya is a live agent-payment platform: one MCP server (https://vaaya.ai/mcp) that lets any agent pay per-call for tools (media/video gen, research, scraping, compute, browser automation, email) with no API keys — x402 (USDC on Base) and Stripe. Fits alongside MCP Pay, Skyfire, PayOS, Payman. Site: https://vaaya.ai