### PR TITLE
Add AgentServices — x402-paid API platform for AI agents (54 services, 37 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository exists to document, track, and make sense of that shift.
 - [AP2 Protocol](https://ap2-protocol.org/)
 - [A2UI Protocol](https://a2ui.org/)
 - [x402 Protocol (Coinbase Crypto Payment Protocol)](https://www.x402.org/)
+- [AgentServices](https://agentservices.to) — Paid API platform for AI agents with 54 services, 97 endpoints, and 41 x402-paid paths. Crypto market data, stock prices, FX rates, news, LLM inference, and image generation. 37 MCP tools. USDC on Base. [MCP server](https://agentservices.to/mcp).
 - [MDN - HTTP 402 Payment Required (Original RFC)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402)
 
 ## 🗂️ Official Github Projects


### PR DESCRIPTION
## What

Adding **AgentServices** ([agentservices.to](https://agentservices.to)) — a production x402-paid API platform for AI agents.

## Key Facts

- **54 services**, **97 endpoints**, **41 x402-paid paths** (USDC on Base)
- **37 MCP tools** — [official MCP Registry](https://registry.modelcontextprotocol.io/v0?search=agentservices) (`to.agentservices/agentservices`, v5.3.0)
- Categories: crypto market data, stock prices, FX rates, news, LLM inference, image generation
- x402 V2 compliant (`x402Version: 2`, `network: eip155:8453`)
- Live MCP endpoint: `https://agentservices.to/mcp`
