### PR TITLE
Add stipend to Platforms & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository exists to document, track, and make sense of that shift.
 - [Saleor](https://saleor.io/agentic-commerce)
 - [OrcaQubits](https://orcaqubits-ai.com/)
 - [Zinc](https://www.zinc.com/)
+- [stipend](https://stipend.sh/)
 
 ## 🧩 Protocol Deep Dives
 


### PR DESCRIPTION
One line in **🧰 Platforms & Tools**, alongside the other agent-side payment infrastructure on that list (Payman, Skyfire, Crossmint, PayOS). Bare-link format, matching its neighbours.

[stipend.sh](https://stipend.sh/) is a non-custodial USDC wallet on Base that an AI agent installs by itself. Per-transaction, per-day and per-counterparty caps plus a destination allowlist are enforced in code between the agent's decision and the signature, rather than in a system prompt. It also ships an MCP server over stdio with 7 tools, and pays HTTP 402 charges buyer-side via EIP-3009.

Source: https://github.com/stipend-sh/stipend (Python, Apache-2.0). Not audited.

Happy to move it to **💻 Notable Github Projects** instead if you would rather list the repo than the product — just say which and I will amend.
