### PR TITLE
Add NEX Agent Co. to Platforms & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository exists to document, track, and make sense of that shift.
 - [CartAI](https://www.cartai.ai/)
 - [Stateset](https://www.stateset.com/)
 - [Simple Checkout](https://simplecheckout.ai/)
+- [NEX Agent Co.](https://nexaitechau.github.io/) - Live x402 + A2A dual-protocol agentic commerce on Base. 11 paid USDC endpoints at $0.001-0.01, 10 free mirrors, 23 on-chain NFTs for ERC-8004-style reputation. Apache-2.0 reference server.
 - [MCP Pay](https://mcpay.tech/)
 - [Skyfire](https://skyfire.xyz/)
 - [PayOS](https://payos.ai/)


### PR DESCRIPTION
Adding [NEX Agent Co.](https://nexaitechau.github.io/) — live x402 + A2A agentic commerce on Base.

**Production-ready today:**
- 11 paid x402 USDC endpoints at $0.001-0.01 each
- 10 free mirrors
- A2A JSON-RPC 2.0 endpoint
- 23 on-chain NFTs (Identity, Pass, Attestation, Receipt) for ERC-8004-style reputation
- Apache-2.0 reference: [NEXAITECHAU/nex-x402-server](https://github.com/NEXAITECHAU/nex-x402-server)

**Live discovery:**
- https://nexaitechau.github.io/agent-card-a2a.json
- https://charm-preparing-avon-ips.trycloudflare.com/.well-known/x402.json
- https://nexaitechau.github.io/live.html